### PR TITLE
fix: Ignora notas fiscais denegadas

### DIFF
--- a/model/data/entity/sales_history_entity.py
+++ b/model/data/entity/sales_history_entity.py
@@ -138,13 +138,17 @@ class SalesHistoryEntity:
 
         if nfe_json_dict["ide"]["dInut"] != "" or nfe_json_dict["ide"]["dCan"] != "":
             classification = "CANCELAMENTO"
+        elif product_json_dict['itemPedido'].get('cItemDevolvido') == 'S':
+            classification = 'DEVOLUCAO'
         else:
-            classification = get_classification_name_by_cfop(str(product_json_dict["CFOP"]).replace(".", ""))
+            classification = get_classification_name_by_cfop(str(product_json_dict['prod']["CFOP"]).replace(".", ""))
 
         date_str = nfe_json_dict["ide"]["dCan"] if nfe_json_dict["ide"]["dCan"] != "" else \
             nfe_json_dict["ide"]["dInut"] if nfe_json_dict["ide"]["dInut"] != "" else nfe_json_dict["ide"]["dEmi"]
 
         date = datetime.strptime(date_str, "%d/%m/%Y")
+
+        product_json_dict = product_json_dict['prod']
 
         return SalesHistoryEntity(
             cnpj_cpf=str(customer_json_dict["cnpj_cpf"]).replace(".", "").replace("/", "").replace("-", ""),

--- a/model/data_provider/omie_data_provider.py
+++ b/model/data_provider/omie_data_provider.py
@@ -37,6 +37,8 @@ class OmieDataProvider:
             __has_data = current_page < nfe_result_json["total_de_paginas"]
 
             for nf_json in nfe_result_json["nfCadastro"]:
+                if nf_json['ide'].get('cDeneg') == 'S':
+                    continue
                 seller_omie_id = nf_json['pedido'].get('nIdVendedor')
                 seller_entity = self.__get_seller(
                     seller_omie_id=seller_omie_id,
@@ -55,7 +57,7 @@ class OmieDataProvider:
                     sales_history_entity = SalesHistoryEntity.from_json(
                         nf_json,
                         customer_result_json,
-                        prod_json["prod"],
+                        prod_json,
                         seller_entity
                     )
 


### PR DESCRIPTION
- As notas fiscais denegadas estavam influenciando na soma total das vendas, levando a divergências de valores, como as notas fiscais denagadas são registradas na sefa, elas tem que ser ignoradas pelo programa
- Foi adicionado uma melhoria para notas fiscais devolvidas